### PR TITLE
Resolví el bug de overflow

### DIFF
--- a/content/monitoreo/agenda-legislativa-lxiii.md
+++ b/content/monitoreo/agenda-legislativa-lxiii.md
@@ -49,5 +49,5 @@ La Agenda Legislativa se aprobó el 27 de enero de 2022 con 32 votos a favor.
 La Agenda Legislativa es fundamental para organizar el trabajo del Congreso y asegurar que se traten temas importantes para la sociedad. La participación de diferentes partidos políticos en su definición garantiza que se consideren diferentes puntos de vista y se busquen soluciones integrales a los problemas del estado.
 
 ## Ver el Acuerdo Legislativo
-<a href="https://congresoweb.congresojal.gob.mx/infolej/agendakioskos/documentos/sistemaintegral/estados/129339.pdf" target="_blank">https://congresoweb.congresojal.gob.mx/infolej/agendakioskos/documentos/sistemaintegral/estados/129339.pdf </a>
+<a href="https://congresoweb.congresojal.gob.mx/infolej/agendakioskos/documentos/sistemaintegral/estados/129339.pdf" target="_blank">Acuerdo Legislativo del Congreso del Estado de Jalisco</a>
 


### PR DESCRIPTION
# El texto ya no hace overflow

## Cambios
Cambié el texto mostrado en la página, ya no muestra la URL completa, sino un texto más corto que sí hace wrap alrededor de la página.

## Antes:
<img width="1314" alt="Captura de pantalla 2023-09-03 a la(s) 11 06 34" src="https://github.com/siguealcongreso/sitioweb/assets/105229933/a3ee9ed7-63e9-43d3-9ecf-3fc2f153c63a">

## Ahora
<img width="305" alt="Captura de pantalla 2023-09-03 a la(s) 11 21 15" src="https://github.com/siguealcongreso/sitioweb/assets/105229933/c1cc2ad6-5901-4600-851f-5c6b4b288be8">
