### PR TITLE
22 actualizar las plantillas de sección

### DIFF
--- a/layouts/areas/lxiii/terms.html
+++ b/layouts/areas/lxiii/terms.html
@@ -1,6 +1,6 @@
-{{ define "main" }}
-  <article class="cf pa3 pa4-m pa4-l">
-    <div class="measure-wide-l center f4 lh-copy nested-copy-line-height nested-links nested-img mid-gray">
+{{ partial "header" . }}
+{{ partial "nav" . }}
+    <div class="container">
       {{ $slice := slice }}
       {{ range ($.Site.GetPage ("/areas/lxiii")).Pages }}
         {{ range $page := .Pages }}
@@ -31,42 +31,37 @@
 
       <!-- {{ if $sintema }} Se muestran {{ sub $pendientes $sintema }} iniciativas en proceso, hay {{ $sintema }} a las que les falta tema y resumen (<a href="/monitoreo/sintema/lxiii">clic para ayudar</a>).{{ end }} -->
     </div>
-  </article>
-  <div class="mw8 center">
-    <section class="ph4">
-      <table>
+  <div class="container">
+    <section class="section">
+      <table class="table table-hover">
 	<tr class="tl"><th>Área</th><th>Cantidad</th><th>Aprobadas</th></tr>
       {{ range .Data.Terms.ByCount }}
         {{ $aprobadas := 0 }}
 	{{ range .Pages }}
           {{ if eq .Params.estado "Aprobado" }}{{ $aprobadas = add $aprobadas 1 }}{{ end }}
 	{{ end }}
-        <tr class="stripe-dark"><td><a href="#{{ .Page.Title }}">{{ .Page.Title }}</a></td>
-	  <td class="tr">{{ .Count }}</td>
-	  <td class="tr">{{ if $aprobadas }}{{ $aprobadas }}{{ end }}</td>
+        <tr><td><a href="/areas/lxiii/#{{ .Page.Title }}">{{ .Page.Title }}</a></td>
+	  <td>{{ .Count }}</td>
+	  <td>{{ if $aprobadas }}{{ $aprobadas }}{{ end }}</td>
 	</tr>
       {{ end }}
       </table>
     </section>
-  </div>
-  <div class="mw8 center">
-    <section class="ph4">
+    <section class="section">
       {{ range .Data.Terms.ByCount }}
-        <h4 id="{{ .Page.Title }}" class="f3">
-          <a href="{{ .Page.Permalink }}" class="link blue hover-black">
+        <h3 id="{{ .Page.Title }}">
+          <a href="{{ .Page.Permalink }}">
             {{ .Page.Title }} {{ .Count }}
           </a>
-        </h4>
-	<table cellspacing="0">
+        </h3>
+	<table class="table table-hover">
 	  {{ range .Pages.ByParam "numero" }}
-	  <tr class="{{ if eq .Params.estado "Aprobado" }}bg-light-green{{ end }}">
-	    <td class="bb b--black-20">{{ index .Params.temas 0 }}</td>
-	    <td class="bb b--black-20">{{ .Params.resumen | markdownify }} (<a href="{{ .Permalink }}">{{ .Params.numero }}</a>)</td>
-	    <!-- <td class="bb b--black-20">{{ .Params.cambios }}</td> -->
+	  <tr class="{{ if eq .Params.estado "Aprobado" }}bg-success-subtle{{ end }}">
+	    <td>{{ index .Params.temas 0 }}</td>
+	    <td>{{ .Params.resumen | markdownify }} (<a href="{{ .Permalink }}">{{ .Params.numero }}</a>)</td>
          </tr>
 	    {{ end }}
         </table>
       {{ end }}
     </section>
-  </div>
-{{ end }}
+{{ partial "footer" . }}

--- a/layouts/comisiones/term.html
+++ b/layouts/comisiones/term.html
@@ -1,16 +1,17 @@
-{{ define "main" }}
-  <article class="cf pa3 pa4-m pa4-l">
-    <div class="measure-wide-l center f4 lh-copy nested-copy-line-height nested-links nested-img mid-gray">
-      <p>{{i18n "taxonomyPageList" .}}</p>
+{{ partial "header" . }}
+{{ partial "nav" . }}
+  <article class="container">
+    <div class="section">
+      <h2>{{ .Title }}</h2>
     </div>
   </article>
-  <div class="mw8 center">    
-    <section class="flex-ns flex-wrap justify-around mt5">
+  <div class="container">
+    <section class="section">
       {{ range  .Pages.ByParam "numero" }}
-        <div class="relative w-100  mb4 bg-white">
-          {{ partial "summary.html" . }}
+        <div>
+          {{ .Title }}
         </div>
       {{ end }}
     </section>
   </div>
-{{ end }}
+{{ partial "footer" . }}

--- a/layouts/comisiones/term.html
+++ b/layouts/comisiones/term.html
@@ -2,14 +2,15 @@
 {{ partial "nav" . }}
   <article class="container">
     <div class="section">
-      <h2>{{ .Title }}</h2>
+      <h1>{{ .Title }}</h1>
     </div>
   </article>
   <div class="container">
     <section class="section">
       {{ range  .Pages.ByParam "numero" }}
+      <h2>{{ .Title }}</h2>
         <div>
-          {{ .Title }}
+          {{ .Summary }}
         </div>
       {{ end }}
     </section>

--- a/layouts/comisiones/terms.html
+++ b/layouts/comisiones/terms.html
@@ -1,6 +1,7 @@
-{{ define "main" }}
-  <article class="cf pa3 pa4-m pa4-l">
-    <div class="measure-wide-l center f4 lh-copy nested-copy-line-height nested-links nested-img mid-gray">
+{{ partial "header" . }}
+{{ partial "nav" . }}
+  <article class="container">
+    <div class="section">
       {{ $slice := slice }}
       {{ range ($.Site.GetPage ("/areas")).Pages }}
         {{ range $page := .Pages }}
@@ -28,40 +29,40 @@
       <!-- {{ if $sintema }} Se muestran {{ sub $pendientes $sintema }} iniciativas en proceso, hay {{ $sintema }} a las que les falta tema y resumen (<a href="/monitoreo/sintema/lxiii">clic para ayudar</a>).{{ end }} -->
     </div>
   </article>
-  <div class="mw8 center">
-    <section class="ph4">
-      <table>
+  <div class="container">
+    <section class="section">
+      <table class="table table-hover">
 	<tr class="tl"><th>Comisión</th><th>Cantidad</th><th>Aprobadas</th></tr>
       {{ range .Data.Terms.ByCount }}
         {{ $aprobadas := 0 }}
 	{{ range .Pages }}
           {{ if eq .Params.estado "Aprobado" }}{{ $aprobadas = add $aprobadas 1 }}{{ end }}
 	{{ end }}
-        <tr class="stripe-dark"><td><a href="#{{ .Page.Title }}">{{ .Page.Title }}</a></td>
-	  <td class="tr">{{ .Count }}</td>
-	  <td class="tr">{{ if $aprobadas }}{{ $aprobadas }}{{ end }}</td>
+        <tr><td><a href="/comisiones/#{{ .Page.Title }}">{{ .Page.Title }}</a></td>
+	  <td>{{ .Count }}</td>
+	  <td>{{ if $aprobadas }}{{ $aprobadas }}{{ end }}</td>
 	</tr>
       {{ end }}
       </table>
     </section>
   </div>
-  <div class="mw8 center">
-    <section class="ph4">
+  <div class="container">
+    <section class="section">
       {{ range .Data.Terms.ByCount }}
-        <h4 id="{{ .Page.Title }}" class="f3">
-          <a href="{{ .Page.Permalink }}" class="link blue hover-black">
+        <h4 id="{{ .Page.Title }}">
+          <a href="{{ .Page.Permalink }}">
             {{ .Page.Title }} {{ .Count }}
           </a>
         </h4>
-	<table cellspacing="0">
+	<table class="table table-hover">
 	  {{ range .Pages.ByParam "numero" }}
-	  <tr class="{{ if eq .Params.estado "Aprobado" }}bg-light-green{{ end }}">
+	  <tr class="{{ if eq .Params.estado "Aprobado" }}bg-success-subtle{{ end }}">
 	    {{ if not (eq (index .Params.municipios 0) "") }}
-	    <td class="bb b--black-20">{{ index .Params.autores_corto 0 }}</td>
-	    <td class="bb b--black-20">{{ .Params.cambios }}(<a href="{{ .Permalink }}">{{ .Params.numero }}</a>)</td>
+	    <td>{{ index .Params.autores_corto 0 }}</td>
+	    <td>{{ .Params.cambios }}(<a href="{{ .Permalink }}">{{ .Params.numero }}</a>)</td>
 	    {{ else }}
-	    <td class="bb b--black-20">{{ index .Params.temas 0 }}</td>
-	    <td class="bb b--black-20">{{ .Params.resumen | markdownify }} (<a href="{{ .Permalink }}">{{ .Params.numero }}</a>)</td>
+	    <td>{{ index .Params.temas 0 }}</td>
+	    <td>{{ .Params.resumen | markdownify }} (<a href="{{ .Permalink }}">{{ .Params.numero }}</a>)</td>
 	    {{ end }}
 	    <!-- <td class="bb b--black-20">{{ .Params.cambios }}</td> -->
          </tr>
@@ -70,4 +71,4 @@
       {{ end }}
     </section>
   </div>
-{{ end }}
+{{ partial "footer" . }}

--- a/layouts/mensual/list.html
+++ b/layouts/mensual/list.html
@@ -1,14 +1,14 @@
-{{ define "main" }}
-  <article class="pa3 pa4-ns nested-copy-line-height nested-img">
-    <section class="cf ph3 ph5-l pv3 pv4-l f4 tc-l center measure-wide lh-copy mid-gray">
+{{ partial "header" . }}
+{{ partial "nav" . }}
+  <article class="container">
+    <section class="section">
       {{- .Content -}}
     </section>
-    <section class="flex-ns flex-wrap justify-around mt5">
+    <section class="section">
       {{ range .Pages }}
-        <div class="relative w-100 w-30-l mb4 bg-white">
+        <div>
           {{- partial "mensual_summary.html" . -}}
         </div>
       {{ end }}
     </section>
   </article>
-{{ end }}

--- a/layouts/mensual/single.html
+++ b/layouts/mensual/single.html
@@ -1,35 +1,36 @@
-{{ define "main" }}
-<aside>
-<div class="ph4 mw8 center">
+{{ partial "header" . }}
+{{ partial "nav" . }}
+<div class="container">
+<div class="pagination">
     {{ with .NextInSection }}
-      <a class="f6 link dim ph3 pv2 mb2 dib black" href="{{.Permalink}}">← {{.Title}}</a>
+      <a class="btn btn-secondary pull-left" href="{{.Permalink}}"><i class="fa fa-chevron-left" aria-hidden="true"></i> {{.Title}}</a>
     {{ else }}
       {{ range where .Parent.Parent.RegularPagesRecursive ".Params.indice" (add (int .Params.indice) -1) }}
-      <a class="f6 link dim ph3 pv2 mb2 dib black" href="{{.Permalink}}">← {{.Title}}</a>{{ end }}
+      <a class="btn btn-secondary pull-left" href="{{.Permalink}}"><i class="fa fa-chevron-left"></i> {{.Title}}</a>{{ end }}
     {{ end }}
     {{ with .PrevInSection }}
-      <a class="f6 link dim ph3 pv2 mb2 dib black" href="{{.Permalink}}">{{.Title}} →</a>
+      <a class="btn btn-secondary pull-right" href="{{.Permalink}}">{{.Title}} <i class="fa fa-chevron-right" aria-hidden="true"></i></a>
     {{ else }}
       {{ range where .Parent.Parent.RegularPagesRecursive ".Params.indice" (add .Params.indice 1) }}
-      <a class="f6 link dim ph3 pv2 mb2 dib black" href="{{.Permalink}}">{{.Title}} →</a>{{ end }}
+      <a class="btn btn-secondary pull-right" href="{{.Permalink}}">{{.Title}} <i class="fa fa-chevron-right" aria-hidden="true"></i></a>{{ end }}
     {{ end }}
 </div>
-</aside>
+  <h1>{{ .Title }}</h2>
 {{- .Content -}}
-<aside>
-<div class="ph4 mw8 center">
+</div>
+<div class="container">
+<div class="pagination">
     {{ with .NextInSection }}
-      <a class="f6 link dim ph3 pv2 mb2 dib black" href="{{.Permalink}}">← {{.Title}}</a>
+      <a class="btn btn-secondary pull-left" href="{{.Permalink}}"><i class="fa fa-chevron-left" aria-hidden="true"></i> {{.Title}}</a>
     {{ else }}
       {{ range where .Parent.Parent.RegularPagesRecursive ".Params.indice" (add (int .Params.indice) -1) }}
-      <a class="f6 link dim ph3 pv2 mb2 dib black" href="{{.Permalink}}">← {{.Title}}</a>{{ end }}
+      <a class="btn btn-secondary pull-left disabled" href="{{.Permalink}}"><i class="fa fa-chevron-left" aria-hidden="true"></i> {{.Title}}</a>{{ end }}
     {{ end }}
     {{ with .PrevInSection }}
-      <a class="f6 link dim ph3 pv2 mb2 dib black" href="{{.Permalink}}">{{.Title}} →</a>
+      <a class="btn btn-secondary pull-right" href="{{.Permalink}}">{{.Title}} <i class="fa fa-chevron-right" aria-hidden="true"></i></a>
     {{ else }}
       {{ range where .Parent.Parent.RegularPagesRecursive ".Params.indice" (add .Params.indice 1) }}
-      <a class="f6 link dim ph3 pv2 mb2 dib black" href="{{.Permalink}}">{{.Title}} →</a>{{ end }}
+      <a class="btn btn-secondary pull-right" href="{{.Permalink}}">{{.Title}} →</a>{{ end }}
     {{ end }}
 </div>
-</aside>
-{{ end }}
+</div>

--- a/layouts/municipios/terms.html
+++ b/layouts/municipios/terms.html
@@ -1,6 +1,6 @@
-{{ define "main" }}
-  <article class="cf pa3 pa4-m pa4-l">
-    <div class="measure-wide-l center f4 lh-copy nested-copy-line-height nested-links nested-img mid-gray">
+{{ partial "header" . }}
+{{ partial "nav" . }}
+    <div class="container">
       {{ $slice := slice }}
       {{ range ($.Site.GetPage ("/areas")).Pages }}
         {{ range $page := .Pages }}
@@ -27,50 +27,46 @@
 
       <!-- {{ if $sintema }} Se muestran {{ sub $pendientes $sintema }} iniciativas en proceso, hay {{ $sintema }} a las que les falta tema y resumen (<a href="/monitoreo/sintema/lxiii">clic para ayudar</a>).{{ end }} -->
     </div>
-  </article>
-  <div class="mw8 center">
-    <section class="ph4">
-      <table>
+  <div class="container">
+    <section class="section">
+      <table class="table table-hover">
 	<tr class="tl"><th>Ejercicio fiscal</th><th>Cantidad</th><th>Aprobadas</th></tr>
       {{ range .Data.Terms }}
         {{ $aprobadas := 0 }}
 	{{ range .Pages }}
           {{ if eq .Params.estado "Aprobado" }}{{ $aprobadas = add $aprobadas 1 }}{{ end }}
 	{{ end }}
-        <tr class="stripe-dark"><td><a href="#{{ .Page.Title }}">{{ .Page.Title }}</a></td>
+        <tr><td><a href="/municipios/#{{ .Page.Title }}">{{ .Page.Title }}</a></td>
 	  <td class="tr">{{ .Count }}</td>
 	  <td class="tr">{{ if $aprobadas }}{{ $aprobadas }}{{ end }}</td>
 	</tr>
       {{ end }}
       </table>
     </section>
-  </div>
-  <div class="mw8 center">
-    <section class="ph4">
+    <section class="section">
       {{ range .Data.Terms.ByCount }}
-        <h4 id="{{ .Page.Title }}" class="f3">
-          <a href="{{ .Page.Permalink }}" class="link blue hover-black">
+        <h4 id="{{ .Page.Title }}">
+          <a href="{{ .Page.Permalink }}">
             {{ .Page.Title }} {{ .Count }}
           </a>
         </h4>
-	<table cellspacing="0">
+	<table class="table table-hover">
 	  {{ range .Pages.ByParam "numero" }}
-	  <tr class="{{ if eq .Params.estado "Aprobado" }}bg-light-green{{ end }}">
+	  <tr class="{{ if eq .Params.estado "Aprobado" }}bg-success-subtle{{ end }}">
 	    {{ if hasPrefix .Params.cambios "Aprueba" }}
-	    <td class="bb b--black-20"></td>
-	    <td class="bb b--black-20">{{ index .Params.autores 0 }}</td>
-	    <td class="bb b--black-20">{{ .Params.cambios }}</td>
-	    <td class="bb b--black-20">(<a href="{{ .Permalink }}">{{ .Params.numero }}</a>)</td>
+	    <td></td>
+	    <td>{{ index .Params.autores 0 }}</td>
+	    <td>{{ .Params.cambios }}</td>
+	    <td>(<a href="{{ .Permalink }}">{{ .Params.numero }}</a>)</td>
 	    {{ else }}
-	    <td class="bb b--black-20">{{ index .Params.temas 0 }}</td>
-	    <td class="bb b--black-20">{{ .Params.resumen | markdownify }} (<a href="{{ .Permalink }}">{{ .Params.numero }}</a>)</td>
-	    <td class="bb b--black-20">{{ .Params.cambios }}</td>
-	    <td class="bb b--black-20">{{ index .Params.autores_corto 0 }}</td>
+	    <td>{{ index .Params.temas 0 }}</td>
+	    <td>{{ .Params.resumen | markdownify }} (<a href="{{ .Permalink }}">{{ .Params.numero }}</a>)</td>
+	    <td>{{ .Params.cambios }}</td>
+	    <td>{{ index .Params.autores_corto 0 }}</td>
 	    {{ end }}
          </tr>
 	    {{ end }}
         </table>
       {{ end }}
     </section>
-  </div>
-{{ end }}
+{{ partial "footer" . }}

--- a/layouts/sintema/list.html
+++ b/layouts/sintema/list.html
@@ -1,13 +1,11 @@
-{{ define "main" }}
-  <article class="cf pa3 pa4-m pa4-l">
-    <div class="measure-wide-l center f4 lh-copy nested-copy-line-height nested-links nested-img mid-gray">
-
+{{ partial "header" . }}
+{{ partial "nav" . }}
+    <div class="container">
       {{ .Content }}
     </div>
-  </article>
-  <div class="mw8 center">
-    <section class="ph4">
-      <table>
+  <div class="container">
+    <section class="section">
+      <table class="table table-hover">
 	<tr class="tl">
 	  <th>1 ¿Qué cambia?</th>
 	  <th>2 ¿Que dice?</th>
@@ -16,7 +14,7 @@
 	</tr>
 	{{ range ($.Site.GetPage ("/monitoreo/iniciativas/lxiii")).Pages.ByParam "numero" }}
 	{{ if and (eq (index .Params.temas 0) "Pendiente") (eq (index .Params.municipios 0) "") }}
-        <tr class="{{ if eq .Params.estado "Aprobado" }}bg-light-green{{ else }}stripe-dark{{ end }}">
+        <tr class="{{ if eq .Params.estado "Aprobado" }}bg-success-subtle{{ else }}stripe-dark{{ end }}">
 	  <td class="tl">{{ .Params.cambios }} (<a href="{{ .Permalink }}">{{ .Params.numero }}</a>)</td>
 	  <td><a href="https://congresoweb.congresojal.gob.mx/infolej/sistemaintegral/infolej/{{ .Params.documento }}" target="_blank">Leer documento</a></td>
 	  <td><a href="/resumen?numero={{ .Params.numero }}" target="_blank">Llenar formulario</a></td>
@@ -26,5 +24,4 @@
       {{ end }}
       </table>
     </section>
-  </div>
-{{ end }}
+{{ partial "footer" . }}

--- a/layouts/temas/terms.html
+++ b/layouts/temas/terms.html
@@ -1,23 +1,28 @@
-{{ define "main" }}
-  <article class="cf pa3 pa4-m pa4-l">
-    <div class="measure-wide-l center f4 lh-copy nested-copy-line-height nested-links nested-img mid-gray">
+{{ partial "header" . }}
+{{ partial "nav" . }}
+<article class="container">
+  <h2>{{ .Title }}</h2>
+    <div class="section">
       {{ .Content }}
     </div>
   </article>
-  <div class="mw8 center">
-    <section class="ph4">
+  <div class="container">
+    <section class="section">
       {{ range .Data.Terms.ByCount }}
-        <h4 class="f3">
-          <a href="{{ .Page.Permalink }}" class="link blue hover-black">
+        <h3>
+          <a href="{{ .Page.Permalink }}">
             {{ .Page.Title }} {{ .Count }}
-          </a><span class="f5">
-	    {{ range .Pages }}<a class="link bg-animate hover-bg-light-blue f5 no-underline br-pill grow ba ph2 pt1 ml1 dib black sans-serif" href="{{ .Permalink }}">{{ .Params.numero }}</a>{{ end }}
+          </a>
+        </h3>
+	  <span>
+	    {{ range .Pages }}
+	    <a class="badge rounded-pill bg-secondary" href="{{ .Permalink }}">{{ .Params.numero }}</a>
+	    {{ end }}
 	  </span>
-        </h4>
         <!-- {{ range .Pages }} -->
         <!--   {{ partial "ficha.html" . }} -->
         <!-- {{ end }} -->
       {{ end }}
     </section>
   </div>
-{{ end }}
+{{ partial "footer" . }}

--- a/static/custom.css
+++ b/static/custom.css
@@ -1,3 +1,7 @@
+.bg-success-subtle {
+    background-color: #9eebcf;
+}
+
 #TableOfContents ul li ul li {
     margin: 0;
 }


### PR DESCRIPTION
## Descripción:
Modifiqué las plantillas de sección y de taxonomías.

## Cambios realizados:
Modifiqué la o las plantillas de estas secciones:

-   sintema
-   mensual

Modifiqué las plantillas de estas taxonomías:

-   areas
-   comisiones
-   municipios
-   temas

Actualicé el archivo `static/custom.css` con el color de fondo para las iniciativas aprobadas.

## Razón de la modificación:
Desplegar el contenido existente en estas secciones y taxonomías, en forma igual o similar al sitio actual.