### PR TITLE
Removido enlace Acerca de en pagina de inicio

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -4,7 +4,6 @@ title: "Sigue al Congreso"
 description: "Monitoreo parlamentario ciudadano"
 ---
 
-[Acerca de](acerca)
 
 [Organización del Congreso](organizacion)
 


### PR DESCRIPTION
Eliminado el enlace "Acerca de" en la pagina de inicio (content/_index.md). 

Resolviendo el issue https://github.com/siguealcongreso/sitioweb/issues/46
